### PR TITLE
Update kafka monitor to use ubi-micro and avoid a lot of CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,13 @@ RUN umask 0022 && \
     make build && \
     chmod a+x insights-kafka-monitor
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-micro:latest
 
 COPY --from=builder /opt/app-root/src/insights-kafka-monitor .
+
+# copy the certificates from builder image
+COPY --from=builder /etc/ssl /etc/ssl
+COPY --from=builder /etc/pki /etc/pki
 
 USER 1001
 


### PR DESCRIPTION
# Description

The image in use, even as it's not used at all at the moment, is very outdated.

I updated the base image to use ubi-micro as the rest of Go based services.

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
